### PR TITLE
fix(lecture-api, security): LikeFeignClient 경로 누락 및 Exception 불일치

### DIFF
--- a/codin-lecture-api/src/main/java/inu/codin/lecture/domain/like/controller/LikeFeignClient.java
+++ b/codin-lecture-api/src/main/java/inu/codin/lecture/domain/like/controller/LikeFeignClient.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@FeignClient(name = "likeClient", url = "${server.feign.url}")
+@FeignClient(name = "likeClient", url = "${server.feign.url}", path = "/likes")
 public interface LikeFeignClient {
 
     @PostMapping

--- a/codin-security/src/main/java/inu/codin/security/filter/ExceptionHandlerFilter.java
+++ b/codin-security/src/main/java/inu/codin/security/filter/ExceptionHandlerFilter.java
@@ -2,6 +2,7 @@ package inu.codin.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inu.codin.common.response.ExceptionResponse;
+import inu.codin.security.exception.JwtException;
 import inu.codin.security.exception.SecurityErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -10,7 +11,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -18,36 +18,33 @@ import java.io.IOException;
 
 /**
  * 예외 처리 필터
- * - 예외 발생 시, 클라이언트에게 응답을 보내는 필터
- * - JwtException 발생 시, INVALID_TOKEN 응답
- * - 그 외 예외 발생 시, INVALID_TOKEN 응답
+ * - JwtException 발생 시, INVALID_TOKEN 응답 (401)
+ * - 그 외 예외 발생 시, INTERNAL_SERVER_ERROR 응답 (500)
  */
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class ExceptionHandlerFilter extends OncePerRequestFilter {
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
+        } catch (JwtException e) {
+            log.warn("[doFilterInternal] JwtException: {}", e.getMessage());
+            sendErrorResponse(response, HttpStatus.UNAUTHORIZED, e.getErrorCode().getMessage());
         } catch (Exception e) {
-            log.warn("[doFilterInternal] Exception in ExceptionHandlerFilter: {}", e.getMessage());
-            sendErrorResponse(response, SecurityErrorCode.INVALID_TOKEN);
+            log.error("[doFilterInternal] Unexpected exception: {}", e.getMessage(), e);
+            sendErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         }
-
     }
 
-    private void sendErrorResponse(HttpServletResponse response, SecurityErrorCode code) throws IOException {
-        ResponseEntity<?> responseEntity = ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ExceptionResponse(code.getMessage(), HttpStatus.UNAUTHORIZED.value()));
-
-        // Set the HttpServletResponse properties
-        response.setStatus(responseEntity.getStatusCode().value());
+    private void sendErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+        response.setStatus(status.value());
         response.setContentType("application/json");
-
-        // Use an ObjectMapper to write the ResponseEntity body as JSON to the response output stream
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.writeValue(response.getWriter(), responseEntity.getBody());
+        objectMapper.writeValue(response.getWriter(), new ExceptionResponse(message, status.value()));
     }
 
 }


### PR DESCRIPTION
…ilter 일괄 401 응답 수정

- LikeFeignClient에 path="/likes" 추가하여 core-api의 /likes/list 엔드포인트와 매칭
- ExceptionHandlerFilter에서 JwtException만 401, 나머지 예외는 500으로 분리 처리

## #️⃣ 연관된 이슈

> #19 

