### PR TITLE
fix: 유저 단과대의 강의실이 아닌 타과대 강의실 또한 리턴에 포함되는 문제 수정

### DIFF
--- a/codin-lecture-api/src/main/java/inu/codin/lecture/domain/lecture/service/LectureRoomService.java
+++ b/codin-lecture-api/src/main/java/inu/codin/lecture/domain/lecture/service/LectureRoomService.java
@@ -33,32 +33,38 @@ public class LectureRoomService {
      * @return List<Map<강의실 호수, 해당 강의실에서 진행되는 강의 스케줄>>
      */
     public List<Map<Integer, List<LectureRoomResponseDto>>> statusOfEmptyRoom() {
-        LocalDateTime now = LocalDateTime.now();
-        DayOfWeek today = now.getDayOfWeek();
+        DayOfWeek today = LocalDateTime.now().getDayOfWeek();
         List<LectureRoom> lectureRooms = lectureRoomRepository.findAllWithSchedulesAndLectures();
 
         UserInfoResponse userInfoResponse = userClientService.fetchUser();
         College userCollege = userInfoResponse.getCollege();
-        if (userCollege == null) {
-            return List.of();
-        }
+        if (userCollege == null) return List.of();
 
         List<Map<Integer, List<LectureRoomResponseDto>>> statusOfRooms = new ArrayList<>(); //배열 인덱스마다 층고를 뜻함
 
         for (int floor = 1; floor <= 5; floor++) { //1번 인덱스 = 1층 강의실
             Map<Integer, List<LectureRoomResponseDto>> floorMap = new HashMap<>(); // 강의실 호수 : 해당 호수에서 진행되는 강의 스케줄
+
             for (LectureRoom lr : lectureRooms){
                 int room = lr.getRoomNum();
-                if ((room / 100) == floor) {
-                    List<LectureRoomResponseDto> emptyRooms = lr.getSchedules().stream()
-                                    .filter(schedule -> schedule.getDayOfWeek().equals(today))
-                                    .filter(schedule -> schedule.getLecture() != null)
-                                    .filter(schedule -> schedule.getLecture().getCollege() != null)
-                                    .filter(schedule -> userCollege.equals(schedule.getLecture().getCollege()))
-                                    .map(schedule -> LectureRoomResponseDto.of(schedule.getLecture(), room, schedule))
-                                    .toList();
-                    floorMap.put(room, emptyRooms);
-                }
+                if (room / 100 != floor) continue;
+
+                // 강의실이 userCollege 소속 강의실인지 먼저 판별
+                boolean belongsToCollege = lr.getSchedules().stream()
+                        .anyMatch(s -> s.getLecture() != null
+                                && s.getLecture().getCollege() != null
+                                && userCollege.equals(s.getLecture().getCollege()));
+                // userCollege 소속 강의실이 아니라면 해당 강의실은 건너뛰기
+                if (!belongsToCollege) continue;
+
+                List<LectureRoomResponseDto> emptyRooms = lr.getSchedules().stream()
+                        .filter(schedule -> schedule.getDayOfWeek().equals(today))
+                        .filter(schedule -> schedule.getLecture() != null)
+                        .filter(schedule -> schedule.getLecture().getCollege() != null)
+                        .filter(schedule -> userCollege.equals(schedule.getLecture().getCollege()))
+                        .map(schedule -> LectureRoomResponseDto.of(schedule.getLecture(), room, schedule))
+                        .toList();
+                floorMap.put(room, emptyRooms);
             }
             statusOfRooms.add(floorMap);
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #13 

## 📝 작업 내용

> 유저 단과대의 강의실이 아닌 타과대 강의실에 대한 key 값이 리턴에 포함되는 문제가 존재했습니다.
유저 단과대를 기준으로 필터링하여 해당 key를 제거했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 강의실 조회 시 사용자의 대학 소속에 따른 필터링 로직 개선

* **리팩토링**
  * 강의실 상태 조회 성능 최적화
  * 조건 분기 로직 단순화 및 null 체크 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->