### PR TITLE
fix: auth 스웨거 안뜨는 문제 해결을 위한 server 수정

### DIFF
--- a/codin-auth/src/main/java/inu/codin/auth/config/SwaggerConfig.java
+++ b/codin-auth/src/main/java/inu/codin/auth/config/SwaggerConfig.java
@@ -48,7 +48,7 @@ public class SwaggerConfig {
                         .addSecuritySchemes("bearerAuth", bearerAuth)
                 )
                 .servers(List.of(
-                        new Server().url(BASE_DOMAIN_URL + "/auth").description("운영 서버"),
+                        new Server().url(BASE_DOMAIN_URL + "/api/auth").description("운영 서버"),
                         new Server().url("http://localhost:" + BASE_PORT).description("로컬 서버")
                 ));
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 

## 📝 작업 내용

> 기존의 BASE_DOMAIN_URL + "/api/auth" -> BASE_DOMAIN_URL + "/api/auth"로 변경

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * 프로덕션 환경의 API 서버 엔드포인트 주소가 API 문서에 반영되도록 업데이트되었습니다. 이를 통해 개발자들이 API 명세서에서 정확한 프로덕션 서버 경로를 확인할 수 있습니다. 로컬 개발 환경 설정과 API의 실제 기능 및 동작은 이 변경의 영향을 받지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->