### PR TITLE
fix: auth 스웨거 안뜨는 문제 해결을 위한 springdoc:swagger-ui 값 추가

### DIFF
--- a/codin-auth/src/main/resources/application.yml
+++ b/codin-auth/src/main/resources/application.yml
@@ -54,6 +54,8 @@ springdoc:
     operationsSorter: method
     disable-swagger-default-url: true
     display-request-duration: true
+    config-url: ${AUTH_SWAGGER_CONFIG}
+    url: ${AUTH_API_DOC}
 
 schedule:
   path: ${SCHEDULE_PATH}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>

## 📝 작업 내용

> auth 스웨거 안뜨는 문제 해결을 위한 springdoc:swagger-ui 값 추가
스웨거에 대한 config를 직접 지정하였습니다.

springdoc: 
    swagger-ui: 
        config-url: ${AUTH_SWAGGER_CONFIG}
        url: ${AUTH_API_DOC}

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Swagger UI 문서 및 설정 URL을 환경 변수를 통해 외부에서 구성 가능하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->