### PR TITLE
fix: 건물 강의실 현황 조회 로직에서 유저의 단과대 기반 필터 조건 삭제

### DIFF
--- a/codin-lecture-api/src/main/java/inu/codin/lecture/domain/lecture/repository/LectureScheduleRepository.java
+++ b/codin-lecture-api/src/main/java/inu/codin/lecture/domain/lecture/repository/LectureScheduleRepository.java
@@ -1,6 +1,5 @@
 package inu.codin.lecture.domain.lecture.repository;
 
-import inu.codin.common.entity.College;
 import inu.codin.lecture.domain.lecture.entity.LectureSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,7 +16,6 @@ public interface LectureScheduleRepository extends JpaRepository<LectureSchedule
     join fetch s.lecture l
     WHERE r.buildingNum = :building
     AND s.dayOfWeek = :dayOfWeek
-    AND l.college = :college
     AND (
         :floor = 0
             OR (r.roomNum between (:floor * 100) and (:floor * 100 + 99))
@@ -26,7 +24,6 @@ public interface LectureScheduleRepository extends JpaRepository<LectureSchedule
     List<LectureSchedule> findSchedulesForEmptyRoom(
             int building,
             int floor,
-            DayOfWeek dayOfWeek,
-            College college
+            DayOfWeek dayOfWeek
     );
 }

--- a/codin-lecture-api/src/main/java/inu/codin/lecture/domain/lecture/service/LectureRoomService.java
+++ b/codin-lecture-api/src/main/java/inu/codin/lecture/domain/lecture/service/LectureRoomService.java
@@ -83,10 +83,6 @@ public class LectureRoomService {
 
         DayOfWeek today = LocalDateTime.now().getDayOfWeek();
 
-        UserInfoResponse userInfoResponse = userClientService.fetchUser();
-        College userCollege = userInfoResponse.getCollege();
-        if (userCollege == null) return List.of();
-
         // 0이면 전체 층, 1~5 사이면 해당 층, 그 외는 예외 처리
         int startFloor = (floor == 0) ? 1 : floor;
         int endFloor = (floor == 0) ? 5 : floor;
@@ -110,7 +106,7 @@ public class LectureRoomService {
         }
 
         List<LectureSchedule> lectureSchedules = lectureScheduleRepository.findSchedulesForEmptyRoom(
-                building, floor, today, userCollege);
+                building, floor, today);
         for (LectureSchedule ls : lectureSchedules) {
             int roomNum = ls.getRoom().getRoomNum();
             int roomFloor = roomNum / 100;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #13 

## 📝 작업 내용

> 건물 강의실 현황 조회 로직에서 유저의 단과대 기반 필터 조건이 존재하여 
같은 단과대 소속이 아닌 수업이 반환되지 않는 문제가 존재했습니다.
이를 삭제하여 해결했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 빈 강의실 검색 기능이 모든 단과대학의 강의실을 조회하도록 개선되었습니다. 이전에는 사용자의 단과대학으로만 제한되어 있었으나, 이제 건물, 층, 요일 기준으로 전체 강의실의 가용 시간을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->