### PR TITLE
feat: Participation에 단과대 필드 추가 및 초기 정보 입력에 학번 추가

### DIFF
--- a/codin-auth/src/main/java/inu/codin/auth/dto/user/UserProfileRequestDto.java
+++ b/codin-auth/src/main/java/inu/codin/auth/dto/user/UserProfileRequestDto.java
@@ -31,4 +31,8 @@ public class UserProfileRequestDto {
     @Schema(description = "학과", example = "COMPUTER_SCI")
     @NotNull
     private Department department;
+
+    @Schema(description = "학번", example = "20201234")
+    @NotBlank
+    private String studentId;
 }

--- a/codin-auth/src/main/java/inu/codin/auth/feign/UserInternalAuthClient.java
+++ b/codin-auth/src/main/java/inu/codin/auth/feign/UserInternalAuthClient.java
@@ -26,6 +26,7 @@ public interface UserInternalAuthClient {
             @RequestParam String name,
             @RequestParam College college,
             @RequestParam Department department,
+            @RequestParam String studentId,
             @RequestPart(value = "userImage", required = false) MultipartFile userImage
     );
 

--- a/codin-auth/src/main/java/inu/codin/auth/service/AuthCommonService.java
+++ b/codin-auth/src/main/java/inu/codin/auth/service/AuthCommonService.java
@@ -56,6 +56,7 @@ public class AuthCommonService extends AbstractAuthService {
                 userProfileRequestDto.getName(),
                 userProfileRequestDto.getCollege(),
                 userProfileRequestDto.getDepartment(),
+                userProfileRequestDto.getStudentId(),
                 userImage);
     }
 

--- a/codin-core/src/main/java/inu/codin/codin/domain/user/controller/UserController.java
+++ b/codin-core/src/main/java/inu/codin/codin/domain/user/controller/UserController.java
@@ -97,7 +97,7 @@ public class UserController {
 
     @Operation(
             summary = "유저 전체적인 정보 수정",
-            description = "닉네임, 이름, 학과, 단과대 정보 수정" +
+            description = "닉네임, 이름, 학과, 단과대, 학번 정보 수정" +
                     "<br><br> MANAGER 권한은 사용 불가 (계정을 지급하기 위함)"
     )
     @PutMapping("/update/info")

--- a/codin-core/src/main/java/inu/codin/codin/domain/user/dto/request/UpdateUserInfoRequestDto.java
+++ b/codin-core/src/main/java/inu/codin/codin/domain/user/dto/request/UpdateUserInfoRequestDto.java
@@ -16,6 +16,9 @@ public record UpdateUserInfoRequestDto(
         College college,
 
         @Schema(description = "학과", example = "COMPUTER_SCI")
-        Department department
+        Department department,
+
+        @Schema(description = "학번", example = "202012345")
+        String studentId
 ) {
 }

--- a/codin-core/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
+++ b/codin-core/src/main/java/inu/codin/codin/domain/user/entity/UserEntity.java
@@ -85,6 +85,10 @@ public class UserEntity extends BaseTimeEntity {
         this.department = department;
     }
 
+    public void updateStudentId(String studentId) {
+        this.studentId = studentId;
+    }
+
     public void updateProfileImageUrl(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
     }

--- a/codin-core/src/main/java/inu/codin/codin/domain/user/internal/inbound/InternalAuthController.java
+++ b/codin-core/src/main/java/inu/codin/codin/domain/user/internal/inbound/InternalAuthController.java
@@ -30,9 +30,10 @@ public class InternalAuthController {
             @RequestParam String name,
             @RequestParam College college,
             @RequestParam Department department,
+            @RequestParam String studentId,
             @RequestPart(value = "userImage", required = false) MultipartFile userImage
     ) {
-        return userInternalService.completeProfile(email, nickname, name, college, department, userImage);
+        return userInternalService.completeProfile(email, nickname, name, college, department, studentId, userImage);
     }
 
     @GetMapping("/suspension-end-date")

--- a/codin-core/src/main/java/inu/codin/codin/domain/user/internal/inbound/UserInternalService.java
+++ b/codin-core/src/main/java/inu/codin/codin/domain/user/internal/inbound/UserInternalService.java
@@ -34,6 +34,7 @@ public class UserInternalService {
                                                    String name,
                                                    College college,
                                                    Department department,
+                                                   String studentId,
                                                    MultipartFile userImage) {
         // 닉네임 중복 체크
         boolean duplicated = userRepository.findByNicknameAndDeletedAtIsNull(nickname).isPresent();
@@ -63,6 +64,7 @@ public class UserInternalService {
         user.updateName(name);
         user.updateCollege(college);
         user.updateDepartment(department);
+        user.updateStudentId(studentId);
         user.updateProfileImageUrl(imageUrl);
         user.activation();
         userRepository.save(user);

--- a/codin-core/src/main/java/inu/codin/codin/domain/user/service/UserService.java
+++ b/codin-core/src/main/java/inu/codin/codin/domain/user/service/UserService.java
@@ -219,6 +219,9 @@ public class UserService {
         if (updateUserInfoRequestDto.department() != null) {
             user.updateDepartment(updateUserInfoRequestDto.department());
         }
+        if (updateUserInfoRequestDto.studentId() != null) {
+            user.updateStudentId(updateUserInfoRequestDto.studentId());
+        }
 
         userRepository.save(user);
         log.info("[유저 정보 업데이트 성공] 사용자 ID: {}, 업데이트된 정보: {}", userId, updateUserInfoRequestDto);

--- a/codin-ticketing-api/src/main/java/inu/codin/codinticketingapi/domain/ticketing/entity/Participation.java
+++ b/codin-ticketing-api/src/main/java/inu/codin/codinticketingapi/domain/ticketing/entity/Participation.java
@@ -3,6 +3,7 @@ package inu.codin.codinticketingapi.domain.ticketing.entity;
 import inu.codin.codinticketingapi.common.entity.BaseEntity;
 import inu.codin.codinticketingapi.domain.admin.entity.Event;
 import inu.codin.codinticketingapi.domain.user.dto.UserInfoResponse;
+import inu.codin.common.entity.College;
 import inu.codin.common.entity.Department;
 import jakarta.persistence.*;
 import lombok.*;
@@ -35,6 +36,10 @@ public class Participation extends BaseEntity {
     @Column(name = "department", nullable = false)
     private Department department;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "college", nullable = false)
+    private College college;
+
     @Column(name = "student_id", nullable = false)
     private String studentId;
 
@@ -58,6 +63,7 @@ public class Participation extends BaseEntity {
         this.name = userInfoResponse.getName();
         this.studentId = userInfoResponse.getStudentId();
         this.department = userInfoResponse.getDepartment();
+        this.college = userInfoResponse.getCollege();
     }
 
     /** 경품 수령 처리 */


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>

## 📝 작업 내용

> Participation에 단과대 필드 추가 및 초기 정보 입력에 학번 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 사용자 프로필 수정 시 학번 정보를 추가하고 관리할 수 있는 기능이 추가되었습니다.
* 행사 참여 기록에 사용자의 단과대학 정보가 함께 저장되어 더 정확한 참여자 정보 관리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->