### PR TITLE
fix: 이벤트 수동 오픈 로직에 티켓팅 시간 업데이트도 추가

### DIFF
--- a/codin-ticketing-api/src/main/java/inu/codin/codinticketingapi/domain/admin/entity/Event.java
+++ b/codin-ticketing-api/src/main/java/inu/codin/codinticketingapi/domain/admin/entity/Event.java
@@ -164,6 +164,10 @@ public class Event extends BaseEntity {
         this.eventStatus = eventStatus;
     }
 
+    public void updateEventTime(LocalDateTime eventTime) {
+        this.eventTime = eventTime;
+    }
+
     public void closeEvent() {
         this.eventStatus = EventStatus.ENDED;
         this.eventEndTime = LocalDateTime.now();

--- a/codin-ticketing-api/src/main/java/inu/codin/codinticketingapi/domain/admin/service/EventAdminService.java
+++ b/codin-ticketing-api/src/main/java/inu/codin/codinticketingapi/domain/admin/service/EventAdminService.java
@@ -218,11 +218,11 @@ public class EventAdminService {
         Event findEvent = findEventById(eventId);
 
         if (findEvent.getEventStatus() == EventStatus.ACTIVE) {
-
             return true;
         }
 
         findEvent.updateStatus(EventStatus.ACTIVE);
+        findEvent.updateEventTime(LocalDateTime.now());
         eventStatusScheduler.deleteOpenEventScheduler(eventId);
 
         return true;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>

## 📝 작업 내용

> 이벤트 수동 오픈 로직에 티켓팅 시간 업데이트도 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이벤트 활성화 시 이벤트 시간이 자동으로 최신 시간으로 업데이트되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->